### PR TITLE
Fixes issue where returning false on onLeave does not stop scroll #23

### DIFF
--- a/src/FullPage.vue
+++ b/src/FullPage.vue
@@ -87,8 +87,8 @@
           $(sectionSelector + '.active').find(slideSelector).eq(activeSlideIndex).addClass('active');
         }
         $(this.$el).fullpage({
-          ...this.options,
           ...this.events,
+          ...this.options,
         });
       },
     },


### PR DESCRIPTION
The callbacks were being overridden when creating the jQuery instance of fullpage. Prioritising the options object over the events object solves the issue - hope this helps!

#23 