### PR TITLE
fix(webpack-config): fixed relative path babel

### DIFF
--- a/demos/webpack/webpack.config.js
+++ b/demos/webpack/webpack.config.js
@@ -27,7 +27,10 @@ module.exports = {
       },
       {
         test: /\.js$/,
-        loader: 'babel-loader'
+        loader: 'babel-loader',
+        options: {
+          filename: './.babelrc'
+        }
       },
       {
         test: /\.(png|jpg|gif|svg)$/,


### PR DESCRIPTION
#69 
Fixed the path for the .babelrc file, this should be specif for each demo project that has a webpack.config.
