### PR TITLE
- Documentation: replace `ssr: false` with `mode: 'client'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,10 +299,10 @@ Vue.use(Fullpage)
 Now inside your `nuxt.config.js`, define your fullpage plugin file inside the `plugins` key like so:
 ```
   plugins: [
-    { src: '~/plugins/fullpage', ssr: false }
+    { src: '~/plugins/fullpage', mode: 'client' }
   ],
 ```
-Note the `ssr:false` option. Not adding this option will cause errors during render time. This option means Nuxt will not render fullpage on the server, rather skip it and run it in the Browser. 
+Note the `mode: 'client'` option. Not adding this option will cause errors during render time. This option means Nuxt will not render fullpage on the server, rather skip it and run it in the Browser. 
 
 Opening the browser you will see Fullpage is working.
 


### PR DESCRIPTION
TL;DR `ssr: false` is to be deprecated and replaced with `mode: 'client'`

According to https://nuxtjs.org/guide/plugins/, since Nuxt.js 2.4, `mode` has been introduced as option of plugins to specify plugin type, possible value are: `client` or `server`. `ssr: false` will be adapted to `mode: 'client'` and deprecated in next major release.

I've tested the replacement and it's working fine. ;) 