### PR TITLE
add destroyOnlyEvents prop to keep html and styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ methods: {
     this.$refs.fullpage.init()
   }
 }
+
+
+```
+### Destroy Only Events
+
+When using transitions between routes, you may need the styles to remain.
+Use the `destroyOnlyEvents` prop to stop full-page from destroying the tags and styles it created.
+
+```html
+<full-page ref="fullpage" :options="options" :destroy-only-events="true">
 ```
 
 
@@ -323,7 +333,7 @@ Now inside your `nuxt.config.js`, define your fullpage plugin file inside the `p
     { src: '~/plugins/fullpage', mode: 'client' }
   ],
 ```
-Note the `mode: 'client'` option. Not adding this option will cause errors during render time. This option means Nuxt will not render fullpage on the server, rather skip it and run it in the Browser. 
+Note the `mode: 'client'` option. Not adding this option will cause errors during render time. This option means Nuxt will not render fullpage on the server, rather skip it and run it in the Browser.
 
 Opening the browser you will see Fullpage is working.
 

--- a/src/FullPage.vue
+++ b/src/FullPage.vue
@@ -35,7 +35,11 @@ function camelToKebab (string) {
       },
       destroy () {
         if (typeof fullpage_api !== 'undefined' && typeof fullpage_api.destroy !== 'undefined') {
-          fullpage_api.destroy('all')
+          if (this.destroyOnlyEvents) {
+            fullpage_api.destroy()
+          } else {
+            fullpage_api.destroy('all')
+          }
         }
       },
       emitEvent (name, args) {
@@ -81,6 +85,10 @@ function camelToKebab (string) {
         required: true
       },
       skipInit: {
+        type: Boolean,
+        default: false
+      },
+      destroyOnlyEvents: {
         type: Boolean,
         default: false
       }


### PR DESCRIPTION
When using transitions between routes, the plugin would destroy all tags and styles while transitioning, which could result in awkward displays, as discussed in #81
This prop will prevent that.