### PR TITLE
Fix: Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ export default {
   data() {
     return {
       options: {
-        licenseKey: 'YOUR_KEY_HEERE',
+        licenseKey: 'YOUR_KEY_HERE',
         menu: '#menu',
         anchors: ['page1', 'page2', 'page3'],
         sectionsColor: ['#41b883', '#ff5f45', '#0798ec'],


### PR DESCRIPTION
Fix small typo in README.md: "YOUR_KEY_HE**E**RE"
